### PR TITLE
Fix for a bug on io_set.name on AWS

### DIFF
--- a/devices/qaic/api/master/QAicInfApi.cpp
+++ b/devices/qaic/api/master/QAicInfApi.cpp
@@ -488,13 +488,13 @@ QStatus QAicInfApi::init(QID qid, QAicEventCallback callback,
     ioDescProto.ParseFromArray(ioDescQData.data, ioDescQData.size);
     if (!entryPoint_.empty() && entryPoint_.compare("default") != 0) {
       for (auto &io_set : ioDescProto.io_sets()) {
-        if (io_set.name().compare(entryPoint_) == 0) {
+        if (io_set.name().find(entryPoint_) != std::string::npos) {
           ioDescProto.clear_selected_set();
           ioDescProto.mutable_selected_set()->CopyFrom(io_set);
           break;
         }
       }
-      if (ioDescProto.selected_set().name().compare(entryPoint_) != 0) {
+      if (ioDescProto.selected_set().name().find(entryPoint_) == std::string::npos) {
         std::cerr << "Failed to match name in iodesc" << std::endl;
         return QS_ERROR;
       }


### PR DESCRIPTION
May not be a clean change but is needed on AWS dl2q.24xlarge. Without this change name() is returning the following. 
```
convert0a"�%�uXzQ��8]"�TNP� �\"�%��&���Eoutput_end_logitss�Z�� %�uXzQ��(^"���� �]"�]"���E{Q�`b"�@^"�(� %�%xY"���uXzQ��X_"���h� �^"�

                                    _"���5 input_ids�� 5

input_mask�� %�uXzQ��8`"��� �_"�
```